### PR TITLE
Update LICENSE.txt

### DIFF
--- a/src/fonts/LICENSE.txt
+++ b/src/fonts/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright 2015, Microsoft Corporation (www.microsoft.com), with Reserved Font Name Selawik.  All Rights Reserved.  Selawik is a trademark of Microsoft Corporation in the United States and/or other countries.
+Copyright 2015, Microsoft Corporation (www.microsoft.com).  All Rights Reserved.  Selawik is a trademark of Microsoft Corporation in the United States and/or other countries.
 
 This Font Software is licensed under the SIL Open Font License, Version 1.1.
 This license is copied below, and is also available with a FAQ at:


### PR DESCRIPTION
A reserved font name isn't a good idea for 2 reasons.

1. It makes the process of collaboration via github cumbersome; if a member
of the general public clicks the 'fork' button up top right, they must
either seek permission from you before-hand to use the RFN, or to
immediately change the font name in the files as part of their first
modification, and then you'll have to change it back.

2. Many websites who self host the font files will modify them, doing
subsetting and format conversion, which are both explicitly defined in the
OFL as kinds of modification subject to the RFN restriction. SIL have been
willing to offer their view that the most popular web font formats are not
format conversions subject to the RFN restriction, but popular web font
bundling service Font Squirrel includes the less popular formats too, which
do. And subsetting remains. So, changing the name or contacting you are
both administrative burdens for these downstream users, and if they do
contact you, for you; and many people won't think carefully about this and
will just do so without asking, which formally terminates their license.
Putting them in that position is not a good situation.

So not having any RFNs is my first preference. I look forward to hearing
your view :)