### PR TITLE
Responsive type ramp

### DIFF
--- a/src/doc/partials/type.hbs
+++ b/src/doc/partials/type.hbs
@@ -70,6 +70,10 @@
         </div>
 
         <div class="row">
+            <div class="col-sm-24">
+                <h3>Classes and mixins</h3>
+                <p>By default, all the Bootstrap classes are all available. You may also use the Basel classes if you would like to more explicitly be connected to the Basel style guide. The basel classes are win-type-*.</p>
+            </div>
             <div class="col-sm-12">
                 <h4>CSS classes</h4>
 

--- a/src/scss/win/_variables.scss
+++ b/src/scss/win/_variables.scss
@@ -2,11 +2,11 @@
 
 // Font Variables
 $win-font-fallbacks:                "Arial", sans-serif !default;
-$win-font-light:                    "Segoe UI Light", "Selawik Light", $win-font-fallbacks !default;
-$win-font-semilight:                "Segoe UI Semilight", "Selawik Semilight", $win-font-fallbacks !default;
+$win-font-light:                    "Segoe UI Light", "Segoe UI", "Selawik Light", $win-font-fallbacks !default;
+$win-font-semilight:                "Segoe UI Semilight", "Segoe UI", "Selawik Semilight", $win-font-fallbacks !default;
 $win-font-normal:                   "Segoe UI", "Selawik", $win-font-fallbacks !default;
-$win-font-semibold:                 "Segoe UI Semibold", "Selawik Semibold", $win-font-fallbacks !default;
-$win-font-bold:                     "Segoe UI Bold", "Selawik Bold", $win-font-fallbacks !default;
+$win-font-semibold:                 "Segoe UI Semibold", "Segoe UI", "Selawik Semibold", $win-font-fallbacks !default;
+$win-font-bold:                     "Segoe UI Bold", "Segoe UI", "Selawik Bold", $win-font-fallbacks !default;
 
 // Responsive Type Ramp key:value
 $win-fonts: (


### PR DESCRIPTION
Updated breakpoints with responsive type ramp.

Also...removed the Fork Me on GitHub ribbon because it was obscuring the hamburger menu on smaller screens. Replaced with a link in the page header. 