### PR TITLE
Basel color

### DIFF
--- a/src/doc/partials/colors.hbs
+++ b/src/doc/partials/colors.hbs
@@ -10,16 +10,18 @@
             <div class="row">
                 <div class="col-md-12">
                     <p class="color win-color-fill-accent"></p>
-
+                </div> 
+                <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $brand-primary: $win-color-fl-accent;
 ```
                     {{/markdown}}
-                </div>   
+                </div>  
                 <div class="col-md-12">
                     <p class="color win-color-fill-50"></p>
-
+                </div>
+                <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $brand-success: $win-color-fl-50;
@@ -28,7 +30,8 @@ $brand-success: $win-color-fl-50;
                 </div>
                 <div class="col-md-12">
                     <p class="color win-color-fill-50"></p>
-
+                </div>
+                <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $brand-info: $win-color-fl-50;
@@ -37,7 +40,8 @@ $brand-info: $win-color-fl-50;
                 </div>      
                 <div class="col-md-12">
                     <p class="color win-color-fill-alert"></p>
-
+                </div>
+                <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $brand-warning: $win-color-fl-alert;
@@ -46,7 +50,8 @@ $brand-warning: $win-color-fl-alert;
                 </div>   
                 <div class="col-md-12">
                     <p class="color win-color-fill-alert"></p>
-
+                </div>
+                <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $brand-danger: $win-color-fl-alert;
@@ -70,7 +75,8 @@ $brand-danger: $win-color-fl-alert;
             <div class="row">
                 <div class="col-md-12">
                     <p class="color win-color-light"></p>
-
+                </div>
+                <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-light: #FFFFFF;
@@ -80,7 +86,8 @@ $win-color-light: #FFFFFF;
 
                 <div class="col-md-12">
                     <p class="color win-color-dark"></p>
-
+                </div>
+                <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-dark: #000000;
@@ -93,7 +100,8 @@ $win-color-dark: #000000;
             <div class="row">
                 <div class="col-md-12">
                     <p class="color win-color-bg-10"></p>
-
+                </div>
+                <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-bg-10: $win-color-light;
@@ -103,7 +111,8 @@ $win-color-bg-10: $win-color-light;
 
                 <div class="col-md-12">
                     <p class="color win-color-bg-20"></p>
-
+                </div>
+                <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-bg-20: #F2F2F2;
@@ -113,7 +122,8 @@ $win-color-bg-20: #F2F2F2;
 
                 <div class="col-md-12">
                     <p class="color win-color-bg-30"></p>
-
+                </div>
+                <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-bg-30: #E5E5E5;
@@ -123,7 +133,8 @@ $win-color-bg-30: #E5E5E5;
 
                 <div class="col-md-12">
                     <p class="color win-color-bg-40"></p>
-
+                </div>
+                <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-bg-40: #D9D9D9;
@@ -133,7 +144,8 @@ $win-color-bg-40: #D9D9D9;
 
                 <div class="col-md-12">
                     <p class="color win-color-bg-50"></p>
-
+                </div>
+                <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-bg-50: #CCCCCC;
@@ -146,7 +158,8 @@ $win-color-bg-50: #CCCCCC;
             <div class="row">
                 <div class="col-md-12">
                     <p class="color win-color-fill-accent"></p>
-
+                </div>
+                <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-accent: #0078D7;
@@ -156,7 +169,8 @@ $win-color-fl-accent: #0078D7;
 
                 <div class="col-md-12">
                     <p class="color win-color-fill-accent-low"></p>
-
+                </div>
+                <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-accent-low: rgba($win-color-fl-accent, 0.4); 
@@ -166,7 +180,8 @@ $win-color-fl-accent-low: rgba($win-color-fl-accent, 0.4);
 
                 <div class="col-md-12">
                     <p class="color win-color-fill-accent-medium"></p>
-
+                </div>
+                <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-accent-medium: rgba($win-color-fl-accent, 0.6);
@@ -176,7 +191,8 @@ $win-color-fl-accent-medium: rgba($win-color-fl-accent, 0.6);
                
                 <div class="col-md-12">
                     <p class="color win-color-fill-accent-high"></p>
-
+                </div>
+                <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-accent-high: rgba($win-color-fl-accent, 0.7);
@@ -186,7 +202,8 @@ $win-color-fl-accent-high: rgba($win-color-fl-accent, 0.7);
 
                 <div class="col-md-12">
                     <p class="color win-color-fill-alert"></p>
-
+                </div>
+                <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-alert: #D02E00;
@@ -196,7 +213,8 @@ $win-color-fl-alert: #D02E00;
 
                 <div class="col-md-12">
                     <p class="color win-color-fill-10"></p>
-
+                </div>
+                <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-10: rgba($win-color-dark, 0.05);
@@ -206,7 +224,8 @@ $win-color-fl-10: rgba($win-color-dark, 0.05);
 
                 <div class="col-md-12">
                     <p class="color win-color-fill-20"></p>
-
+                </div>
+                <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-20: rgba($win-color-dark, 0.1);
@@ -216,7 +235,8 @@ $win-color-fl-20: rgba($win-color-dark, 0.1);
 
                 <div class="col-md-12">
                     <p class="color win-color-fill-30"></p>
-
+                </div>
+                <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-30: rgba($win-color-dark, 0.2);
@@ -226,7 +246,8 @@ $win-color-fl-30: rgba($win-color-dark, 0.2);
 
                 <div class="col-md-12">
                     <p class="color win-color-fill-40"></p>
-
+                </div>
+                <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-40: rgba($win-color-dark, 0.4);
@@ -236,7 +257,8 @@ $win-color-fl-40: rgba($win-color-dark, 0.4);
 
                 <div class="col-md-12">
                     <p class="color win-color-fill-50"></p>
-
+                </div>
+                <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-50: rgba($win-color-dark, 0.6);
@@ -246,7 +268,8 @@ $win-color-fl-50: rgba($win-color-dark, 0.6);
 
                 <div class="col-md-12">
                     <p class="color win-color-fill-60"></p>
-
+                </div>
+                <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-60: rgba($win-color-dark, 0.8);
@@ -256,7 +279,8 @@ $win-color-fl-60: rgba($win-color-dark, 0.8);
 
                 <div class="col-md-12">
                     <p class="color win-color-fill-70"></p>
-
+                </div>
+                <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-70: $win-color-dark;
@@ -269,7 +293,8 @@ $win-color-fl-70: $win-color-dark;
             <div class="row">
                 <div class="col-md-12">
                     <p class="color line win-color-line-accent"></p>
-
+                </div>
+                <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-accent: #0078D7;
@@ -279,7 +304,8 @@ $win-color-fl-accent: #0078D7;
 
                 <div class="col-md-12">
                     <p class="color line win-color-line-accent-low"></p>
-
+                </div>
+                <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-accent-low: rgba($win-color-fl-accent, 0.4); 
@@ -289,7 +315,8 @@ $win-color-fl-accent-low: rgba($win-color-fl-accent, 0.4);
 
                 <div class="col-md-12">
                     <p class="color line win-color-line-accent-medium"></p>
-
+                </div>
+                <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-accent-medium: rgba($win-color-fl-accent, 0.6);
@@ -299,7 +326,8 @@ $win-color-fl-accent-medium: rgba($win-color-fl-accent, 0.6);
                
                 <div class="col-md-12">
                     <p class="color line win-color-line-accent-high"></p>
-
+                </div>
+                <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-accent-high: rgba($win-color-fl-accent, 0.7);
@@ -309,7 +337,8 @@ $win-color-fl-accent-high: rgba($win-color-fl-accent, 0.7);
 
                 <div class="col-md-12">
                     <p class="color line win-color-line-alert"></p>
-
+                </div>
+                <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-alert: #D02E00;
@@ -319,7 +348,8 @@ $win-color-fl-alert: #D02E00;
 
                 <div class="col-md-12">
                     <p class="color line win-color-line-10"></p>
-
+                </div>
+                <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-10: rgba($win-color-dark, 0.05);
@@ -329,7 +359,8 @@ $win-color-fl-10: rgba($win-color-dark, 0.05);
 
                 <div class="col-md-12">
                     <p class="color line win-color-line-20"></p>
-
+                </div>
+                <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-20: rgba($win-color-dark, 0.1);
@@ -339,7 +370,8 @@ $win-color-fl-20: rgba($win-color-dark, 0.1);
 
                 <div class="col-md-12">
                     <p class="color line win-color-line-30"></p>
-
+                </div>
+                <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-30: rgba($win-color-dark, 0.2);
@@ -349,7 +381,8 @@ $win-color-fl-30: rgba($win-color-dark, 0.2);
 
                 <div class="col-md-12">
                     <p class="color line win-color-line-40"></p>
-
+                </div>
+                <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-40: rgba($win-color-dark, 0.4);
@@ -359,7 +392,8 @@ $win-color-fl-40: rgba($win-color-dark, 0.4);
 
                 <div class="col-md-12">
                     <p class="color line win-color-line-50"></p>
-
+                </div>
+                <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-50: rgba($win-color-dark, 0.6);
@@ -369,7 +403,8 @@ $win-color-fl-50: rgba($win-color-dark, 0.6);
 
                 <div class="col-md-12">
                     <p class="color line win-color-line-60"></p>
-
+                </div>
+                <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-60: rgba($win-color-dark, 0.8);
@@ -379,7 +414,8 @@ $win-color-fl-60: rgba($win-color-dark, 0.8);
 
                 <div class="col-md-12">
                     <p class="color line win-color-line-70"></p>
-
+                </div>
+                <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-70: $win-color-dark;
@@ -392,7 +428,8 @@ $win-color-fl-70: $win-color-dark;
             <div class="row">
                 <div class="col-md-12">
                     <p class="color win-color-type-primary">Primary</p>
-
+                </div>
+                <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-type-primary: $win-color-dark;
@@ -402,7 +439,8 @@ $win-color-type-primary: $win-color-dark;
 
                 <div class="col-md-12">
                     <p class="color win-color-type-secondary">Secondary</p>
-
+                </div>
+                <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-type-secondary: rgba($win-color-type-primary, 0.6);
@@ -412,7 +450,8 @@ $win-color-type-secondary: rgba($win-color-type-primary, 0.6);
 
                 <div class="col-md-12">
                     <p class="color win-color-type-disabled">Disabled</p>
-
+                </div>
+                <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-type-disabled: rgba($win-color-type-primary, 0.2);
@@ -422,7 +461,8 @@ $win-color-type-disabled: rgba($win-color-type-primary, 0.2);
 
                 <div class="col-md-12">
                     <p class="color win-color-type-accent">Accent</p>
-
+                </div>
+                <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-type-accent: #0078D7;
@@ -430,10 +470,10 @@ $win-color-type-accent: #0078D7;
                     {{/markdown}}
                 </div>        
 
-                <div class="clearfix visible-md"></div> <!-- Help clear when Disabled PRE wraps on smaller viewport -->
                 <div class="col-md-12">
                     <p class="color win-color-type-alert">Alert</p>
-
+                </div>
+                <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-type-alert: #D02E00;
@@ -458,7 +498,8 @@ $win-color-type-alert: #D02E00;
                 <div class="row">
                     <div class="col-md-12">
                         <p class="color win-color-bg-10-alt"></p>
-
+                    </div>
+                    <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-bg-10-alt: $win-color-dark;
@@ -468,7 +509,8 @@ $win-color-bg-10-alt: $win-color-dark;
 
                     <div class="col-md-12">
                         <p class="color win-color-bg-20-alt"></p>
-
+                    </div>
+                    <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-bg-20-alt: #191919;
@@ -478,7 +520,8 @@ $win-color-bg-20-alt: #191919;
 
                     <div class="col-md-12">
                         <p class="color win-color-bg-30-alt"></p>
-
+                    </div>
+                    <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-bg-30-alt: #262626;
@@ -488,7 +531,8 @@ $win-color-bg-30-alt: #262626;
 
                     <div class="col-md-12">
                         <p class="color win-color-bg-40-alt"></p>
-
+                    </div>
+                    <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-bg-40-alt: #333333;
@@ -498,7 +542,8 @@ $win-color-bg-40-alt: #333333;
 
                     <div class="col-md-12">
                         <p class="color win-color-bg-50-alt"></p>
-
+                    </div>
+                    <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-bg-50-alt: #404040;
@@ -511,7 +556,8 @@ $win-color-bg-50-alt: #404040;
                 <div class="row">
                     <div class="col-md-12">
                         <p class="color win-color-fill-accent-alt"></p>
-
+                    </div>
+                    <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-accent-alt: $win-color-fl-accent;
@@ -521,7 +567,8 @@ $win-color-fl-accent-alt: $win-color-fl-accent;
 
                     <div class="col-md-12">
                         <p class="color win-color-fill-accent-low-alt"></p>
-
+                    </div>
+                    <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-accent-low-alt: rgba($win-color-fl-accent, 0.4); 
@@ -531,7 +578,8 @@ $win-color-fl-accent-low-alt: rgba($win-color-fl-accent, 0.4);
 
                     <div class="col-md-12">
                         <p class="color win-color-fill-accent-medium-alt"></p>
-
+                    </div>
+                    <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-accent-medium-alt: rgba($win-color-fl-accent, 0.6);
@@ -541,7 +589,8 @@ $win-color-fl-accent-medium-alt: rgba($win-color-fl-accent, 0.6);
                    
                     <div class="col-md-12">
                         <p class="color win-color-fill-accent-high-alt"></p>
-
+                    </div>
+                    <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-accent-high-alt: rgba($win-color-fl-accent, 0.7);
@@ -549,10 +598,10 @@ $win-color-fl-accent-high-alt: rgba($win-color-fl-accent, 0.7);
                     {{/markdown}}
                     </div>
 
-                    <div class="clearfix visible-lg"></div> <!-- Helps clear when $win-color-fl-accent-meduim-alt PRE wraps to 2 lines -->
                     <div class="col-md-12">
                         <p class="color win-color-fill-alert-alt"></p>
-
+                    </div>
+                    <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-alert-alt: #D02E00;
@@ -562,7 +611,8 @@ $win-color-fl-alert-alt: #D02E00;
 
                     <div class="col-md-12">
                         <p class="color win-color-fill-10-alt"></p>
-
+                    </div>
+                    <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-10-alt: rgba(255,255,255,.1);
@@ -572,7 +622,8 @@ $win-color-fl-10-alt: rgba(255,255,255,.1);
 
                     <div class="col-md-12">
                         <p class="color win-color-fill-20-alt"></p>
-
+                    </div>
+                    <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-20-alt: rgba(255,255,255,.15);
@@ -582,7 +633,8 @@ $win-color-fl-20-alt: rgba(255,255,255,.15);
 
                     <div class="col-md-12">
                         <p class="color win-color-fill-30-alt"></p>
-
+                    </div>
+                    <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-30-alt: rgba(255,255,255,.3);
@@ -590,10 +642,10 @@ $win-color-fl-30-alt: rgba(255,255,255,.3);
                     {{/markdown}}
                     </div>        
 
-                    <div class="clearfix visible-md"></div> <!-- Helps clear when $win-color-fl-20-alt PRE wraps to 2 lines -->
                     <div class="col-md-12">
                         <p class="color win-color-fill-40-alt"></p>
-
+                    </div>
+                    <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-40-alt: rgba(255,255,255,.4);
@@ -603,7 +655,8 @@ $win-color-fl-40-alt: rgba(255,255,255,.4);
 
                     <div class="col-md-12">
                         <p class="color win-color-fill-50-alt"></p>
-
+                    </div>
+                    <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-50-alt: rgba(255,255,255,.6);
@@ -613,7 +666,8 @@ $win-color-fl-50-alt: rgba(255,255,255,.6);
 
                     <div class="col-md-12">
                         <p class="color win-color-fill-60-alt"></p>
-
+                    </div>
+                    <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-60-alt: rgba(255,255,255,.8);
@@ -623,7 +677,8 @@ $win-color-fl-60-alt: rgba(255,255,255,.8);
 
                     <div class="col-md-12">
                         <p class="color win-color-fill-70-alt"></p>
-
+                    </div>
+                    <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-70-alt: #FFFFFF;
@@ -636,7 +691,8 @@ $win-color-fl-70-alt: #FFFFFF;
                 <div class="row">
                     <div class="col-md-12">
                         <p class="color line win-color-line-accent-alt"></p>
-
+                    </div>
+                    <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-accent-alt: #0078D7;
@@ -646,7 +702,8 @@ $win-color-fl-accent-alt: #0078D7;
 
                     <div class="col-md-12">
                         <p class="color line win-color-line-accent-low-alt"></p>
-
+                    </div>
+                    <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-accent-low-alt: rgba($win-color-fl-accent, 0.4); 
@@ -656,7 +713,8 @@ $win-color-fl-accent-low-alt: rgba($win-color-fl-accent, 0.4);
 
                     <div class="col-md-12">
                         <p class="color line win-color-line-accent-medium-alt"></p>
-
+                    </div>
+                    <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-accent-medium-alt: rgba($win-color-fl-accent, 0.6);
@@ -666,7 +724,8 @@ $win-color-fl-accent-medium-alt: rgba($win-color-fl-accent, 0.6);
                    
                     <div class="col-md-12">
                         <p class="color line win-color-line-accent-high-alt"></p>
-
+                    </div>
+                    <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-accent-high-alt: rgba($win-color-fl-accent, 0.7);
@@ -674,10 +733,10 @@ $win-color-fl-accent-high-alt: rgba($win-color-fl-accent, 0.7);
                     {{/markdown}}
                     </div>
 
-                    <div class="clearfix visible-lg"></div> <!-- Helps clear when $win-color-fl-accent-medium PRE wraps to 2 lines -->
                     <div class="col-md-12">
                         <p class="color line win-color-line-alert-alt"></p>
-
+                    </div>
+                    <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-alert-alt: #D02E00;
@@ -687,7 +746,8 @@ $win-color-fl-alert-alt: #D02E00;
 
                     <div class="col-md-12">
                         <p class="color line win-color-line-10-alt"></p>
-
+                    </div>
+                    <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-10-alt: rgba($win-color-light, 0.1);
@@ -697,7 +757,8 @@ $win-color-fl-10-alt: rgba($win-color-light, 0.1);
 
                     <div class="col-md-12">
                         <p class="color line win-color-line-20-alt"></p>
-
+                    </div>
+                    <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-20-alt: rgba($win-color-light, 0.15);
@@ -707,7 +768,8 @@ $win-color-fl-20-alt: rgba($win-color-light, 0.15);
 
                     <div class="col-md-12">
                         <p class="color line win-color-line-30-alt"></p>
-
+                    </div>
+                    <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-30-alt: rgba($win-color-light, 0.2);
@@ -717,7 +779,8 @@ $win-color-fl-30-alt: rgba($win-color-light, 0.2);
 
                     <div class="col-md-12">
                         <p class="color line win-color-line-40-alt"></p>
-
+                    </div>
+                    <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-40-alt: rgba($win-color-light, 0.4);
@@ -727,7 +790,8 @@ $win-color-fl-40-alt: rgba($win-color-light, 0.4);
 
                     <div class="col-md-12">
                         <p class="color line win-color-line-50-alt"></p>
-
+                    </div>
+                    <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-50-alt: rgba($win-color-light, 0.6);
@@ -737,7 +801,8 @@ $win-color-fl-50-alt: rgba($win-color-light, 0.6);
 
                     <div class="col-md-12">
                         <p class="color line win-color-line-60-alt"></p>
-
+                    </div>
+                    <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-60-alt: rgba($win-color-light, 0.8);
@@ -747,7 +812,8 @@ $win-color-fl-60-alt: rgba($win-color-light, 0.8);
 
                     <div class="col-md-12">
                         <p class="color line win-color-line-70-alt"></p>
-
+                    </div>
+                    <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-fl-70-alt: $win-color-light;
@@ -760,7 +826,8 @@ $win-color-fl-70-alt: $win-color-light;
                 <div class="row">
                     <div class="col-md-12">
                         <p class="color win-color-type-primary-alt">Primary</p>
-
+                    </div>
+                    <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-type-primary-alt: $win-color-light;
@@ -770,7 +837,8 @@ $win-color-type-primary-alt: $win-color-light;
 
                     <div class="col-md-12">
                         <p class="color win-color-type-secondary-alt">Secondary</p>
-
+                    </div>
+                    <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-type-secondary-alt: rgba($win-color-type-primary-alt, 0.6);
@@ -780,7 +848,8 @@ $win-color-type-secondary-alt: rgba($win-color-type-primary-alt, 0.6);
 
                     <div class="col-md-12">
                         <p class="color win-color-type-disabled-alt">Disabled</p>
-
+                    </div>
+                    <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-type-disabled-alt: rgba($win-color-type-primary-alt, 0.2);
@@ -790,7 +859,8 @@ $win-color-type-disabled-alt: rgba($win-color-type-primary-alt, 0.2);
 
                     <div class="col-md-12">
                         <p class="color win-color-type-accent-alt">Accent</p>
-
+                    </div>
+                    <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-type-accent-alt: #0078D7;
@@ -798,10 +868,10 @@ $win-color-type-accent-alt: #0078D7;
                     {{/markdown}}
                     </div>
 
-                    <div class="clearfix"></div> <!-- Helps clear when $win-color-disabled-type-alt PRE wraps to 2 lines -->
                     <div class="col-md-12">
                         <p class="color win-color-type-alert-alt">Alert</p>
-
+                    </div>
+                    <div class="col-md-12">
                     {{#markdown}}
 ```scss
 $win-color-type-alert-alt: #D02E00;

--- a/src/scss/win/_doc.scss
+++ b/src/scss/win/_doc.scss
@@ -6,12 +6,12 @@
 
 .color {
     height: 0;
-    padding-bottom: 25%;
+    padding-bottom: 8.5%;
 }
 
 .line {
     border: 5px solid;
-    padding: -5px;
+    padding-bottom: 6.5%;
 }
 
 // Basel base colors


### PR DESCRIPTION
Updated colors & variable names based on Basel style guide. Replaced old colors & variables. Left in primary, secondary, tertiary colors for backwards compatibility. 