### PR TITLE
Update override/_bootstrap.scss

### DIFF
--- a/src/scss/override/_bootstrap.scss
+++ b/src/scss/override/_bootstrap.scss
@@ -6,6 +6,7 @@
 @import "../../../bower_components/bootstrap-sass/assets/stylesheets/bootstrap/mixins/image";
 @import "../../../bower_components/bootstrap-sass/assets/stylesheets/bootstrap/mixins/labels";
 @import "../../../bower_components/bootstrap-sass/assets/stylesheets/bootstrap/mixins/reset-filter";
+@import "../../../bower_components/bootstrap-sass/assets/stylesheets/bootstrap/mixins/reset-text";
 @import "../../../bower_components/bootstrap-sass/assets/stylesheets/bootstrap/mixins/resize";
 @import "../../../bower_components/bootstrap-sass/assets/stylesheets/bootstrap/mixins/responsive-visibility";
 @import "../../../bower_components/bootstrap-sass/assets/stylesheets/bootstrap/mixins/size";


### PR DESCRIPTION
Build was broken due to Bootstrap-sass update. Added import of new reset-text mixin file.