### PR TITLE
create example alternate configuration for winstrap

### DIFF
--- a/src/scss/override/_bootstrap-optional.scss
+++ b/src/scss/override/_bootstrap-optional.scss
@@ -1,0 +1,78 @@
+﻿// Variables
+@import "bootstrap-sass/assets/stylesheets/bootstrap/variables";
+// Mixins: Utilities
+@import "bootstrap-sass/assets/stylesheets/bootstrap/mixins/hide-text";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/mixins/opacity";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/mixins/image";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/mixins/labels";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/mixins/reset-filter";
+// @import "bootstrap-sass/assets/stylesheets/bootstrap/mixins/reset-text";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/mixins/resize";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/mixins/responsive-visibility";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/mixins/size";
+// @import "bootstrap-sass/assets/stylesheets/bootstrap/mixins/tab-focus";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/mixins/text-emphasis";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/mixins/text-overflow";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/mixins/vendor-prefixes";
+// Mixins: Components
+@import "bootstrap-sass/assets/stylesheets/bootstrap/mixins/alerts";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/mixins/buttons";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/mixins/panels";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/mixins/pagination";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/mixins/list-group";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/mixins/nav-divider";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/mixins/forms";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/mixins/progress-bar";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/mixins/table-row";
+// Mixins: Skins
+@import "bootstrap-sass/assets/stylesheets/bootstrap/mixins/background-variant";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/mixins/border-radius";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/mixins/gradients";
+// Mixins: Layout
+@import "bootstrap-sass/assets/stylesheets/bootstrap/mixins/clearfix";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/mixins/center-block";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/mixins/nav-vertical-align";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/mixins/grid-framework";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/mixins/grid";
+// Reset and dependencies
+@import "bootstrap-sass/assets/stylesheets/bootstrap/normalize";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/print";
+// @import "bootstrap-sass/assets/stylesheets/bootstrap/glyphicons";
+// Core CSS
+@import "bootstrap-sass/assets/stylesheets/bootstrap/scaffolding";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/type";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/code";
+// @import "bootstrap-sass/assets/stylesheets/bootstrap/grid";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/tables";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/forms";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/buttons";
+// Components
+@import "bootstrap-sass/assets/stylesheets/bootstrap/component-animations";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/dropdowns";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/button-groups";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/input-groups";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/navs";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/navbar";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/breadcrumbs";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/pagination";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/pager";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/labels";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/badges";
+// @import "bootstrap-sass/assets/stylesheets/bootstrap/jumbotron";
+// @import "bootstrap-sass/assets/stylesheets/bootstrap/thumbnails";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/alerts";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/progress-bars";
+// @import "bootstrap-sass/assets/stylesheets/bootstrap/media";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/list-group";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/panels";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/responsive-embed";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/wells";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/close";
+// Components w/ JavaScript
+@import "bootstrap-sass/assets/stylesheets/bootstrap/modals";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/tooltip";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/popovers";
+// @import "bootstrap-sass/assets/stylesheets/bootstrap/carousel";
+// Utility classes
+@import "bootstrap-sass/assets/stylesheets/bootstrap/utilities";
+@import "bootstrap-sass/assets/stylesheets/bootstrap/responsive-utilities";

--- a/src/scss/winstrap-optional.scss
+++ b/src/scss/winstrap-optional.scss
@@ -18,6 +18,11 @@
 @import "win/grid";
 
 //optional bootstrap configuration without grid as example.
+/* when a project includes winstrap, it might want to pick and choose what parts of bootstrap 
+to include instead of the default set of bootstrap components winstrap selects automatically. 
+This demonstrates how to do this for a project that happens to override the bootstrap grid in 
+order to substitute it with another grid. instead of @import "winstrap/src/scss/winstrap", use
+@import "winstrap/src/scss/winstrap-optional" in your project's scss */
 @import "override/bootstrap-optional";
 @import "win/icons";
 @import "win/utilities";

--- a/src/scss/winstrap-optional.scss
+++ b/src/scss/winstrap-optional.scss
@@ -1,0 +1,69 @@
+﻿@charset "UTF-8";
+
+// New mixins and mixins that completely replace
+// bootstrap mixins
+@import "win/mixins/colors";
+@import "win/mixins/animations";
+@import "win/mixins/triangle";
+@import "win/mixins/spacer";
+@import "override/mixins/tab-focus";
+
+// Settings
+@import "win/resources";
+@import "win/colors";
+@import "win/variables";
+@import "override/variables";
+
+// Base
+@import "win/grid";
+
+//optional bootstrap configuration without grid as example.
+@import "override/bootstrap-optional";
+@import "win/icons";
+@import "win/utilities";
+@import "win/type";
+
+// Mixins that override bootstrap mixins
+@import "override/mixins/buttons";
+
+// Overridden components
+@import "override/grid";
+@import "override/scaffolding";
+@import "override/labels";
+@import "override/navs";
+@import "override/breadcrumb";
+@import "override/alerts";
+@import "override/navbar";
+@import "override/modal";
+@import "override/buttons";
+@import "override/dropdown";
+@import "override/tooltip";
+@import "override/popover";
+@import "override/progress-bar";
+@import "override/panels";
+@import "override/forms";
+@import "override/pagination";
+@import "override/tables";
+@import "override/jumbotron";
+
+// New components
+@import "win/scaffolding";
+@import "win/buttons";
+@import "win/rating";
+@import "win/media";
+@import "win/section";
+@import "win/lists";
+@import "win/back-to-top";
+@import "win/progress-ring";
+@import "win/progress-bar";
+@import "win/panels";
+@import "win/alerts";
+@import "win/pager";
+@import "win/pagination";
+
+// Layout
+@import "win/main";
+@import "override/page";
+
+// Pages
+@import "win/doc";

--- a/test.txt
+++ b/test.txt
@@ -1,1 +1,0 @@
-ECHO is on.


### PR DESCRIPTION
when a project includes winstrap, it might want to pick and choose what parts of bootstrap to include instead of the default set of bootstrap components winstrap selects automatically.  This demonstrates how to do this for a project that happens to override the bootstrap grid in order to substitute it with another grid.  instead of `@import "winstrap/src/scss/winstrap"`, use `@import "winstrap/src/scss/winstrap-optional"` in your project's scss