### PR TITLE
Fixing 404 errors in Edge and IE caused by invalid source paths

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -58,7 +58,7 @@ module.exports = function (grunt) {
         {
           expand: true,
           cwd: 'bower_components/jquery/dist/',
-          src: 'jquery.min.js',
+          src: ['jquery.min.js', 'jquery.min.map'],
           dest: 'dist/js/vendor/'
         },
         {
@@ -129,7 +129,7 @@ module.exports = function (grunt) {
       server: {
         options: {
           port: 9001,
-          base: './dist/',
+          base: ['./', './dist/'],
           hostname: 'localhost',
           livereload: true,
           open: true

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
         "grunt-contrib-watch": "^0.6.1",
         "grunt-file-exists": "^0.1.2",
         "grunt-notify": "^0.4.1",
-        "grunt-sass": "^0.18.0",
+        "grunt-sass": "^1.0.0",
         "jshint-stylish": "^2.0.0"
     },
     "scripts": {


### PR DESCRIPTION
404 errors are due to incorrect pathing / file location of pre-compiled source files and source maps. Updating grunt-sass to v1.0.0 corrects the output paths created when the source-map file is compiled to reflect the actual file structure. Adding jquery.min.map to the copy task corrects pathing issues between jquery.min.js and the requested jquery.min.map. Adding './' to the base property of the connect task allows files to be requested relative to the root project level, preserving file paths generated relative to the root level.