### PR TITLE
Side nav

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -76,6 +76,7 @@ module.exports = function (grunt) {
       options: {
         partials: ['src/doc/partials/**/*.hbs'],
         layout: ['src/doc/layouts/default.hbs'],
+        helpers: ['handlebars-helpers/*.js'],
         flatten: true,
         data: 'src/doc/data/*.json',
 

--- a/handlebars-helpers/inArrayJson.js
+++ b/handlebars-helpers/inArrayJson.js
@@ -1,0 +1,16 @@
+//
+// {{#inArrayJson}} handlebars helper
+// {{#inArrayJson [{"foo":"bar"}] "bar"}} //true
+// {{#inArrayJson [{"foo":"bar"}] "foo"}} //true
+// {{#inArrayJson [{"foo":"bar"}] "boo"}} //false
+
+module.exports.register = function(Handlebars, options) {
+    options = options || {};
+    Handlebars.registerHelper('inArrayJson', function(arr, attr, options) {
+        if (JSON.stringify(arr).indexOf(attr) > 0) {
+            return options.fn(this);
+        } else {
+            return options.inverse(this);
+        }
+    });
+};

--- a/src/doc/controls.hbs
+++ b/src/doc/controls.hbs
@@ -37,6 +37,9 @@
                     <li role="presentation">
                         <a href="#navs">Navbar</a>
                     </li>
+                    <li role="presentation">
+                        <a href="#side-nav">Side Navigation</a>
+                    </li>
                 </ul>
             </div>
         </div>
@@ -64,4 +67,6 @@
     {{> tabs }}
     <hr />
     {{> navbar-doc }}
+    <hr />
+    {{> side-navigation }}
 </div>

--- a/src/doc/data/side-nav-large.json
+++ b/src/doc/data/side-nav-large.json
@@ -1,5 +1,5 @@
 {
-    "label": "Mountain Ranges",
+    "category": "Mountain Ranges",
     "pages": [{
         "label": "The Cascades",
         "href": "cascades"

--- a/src/doc/data/side-nav-large.json
+++ b/src/doc/data/side-nav-large.json
@@ -1,0 +1,19 @@
+{
+    "label": "Mountain Ranges",
+    "pages": [{
+        "label": "The Cascades",
+        "href": "cascades"
+    }, {
+        "label": "The Olympic Mountains",
+        "href": "olympic-mountains"
+    }, {
+        "label": "The Sierra Nevadas",
+        "href": "sierra-nevadas"
+    }, {
+        "label": "The Rocky Mountains",
+        "href": "rocky-mountains"
+    }, {
+        "label": "Appalachian Mountains",
+        "href": "appalachain-mountains"
+    }]
+}

--- a/src/doc/data/side-nav-large.json
+++ b/src/doc/data/side-nav-large.json
@@ -5,7 +5,8 @@
         "href": "cascades"
     }, {
         "label": "The Olympic Mountains",
-        "href": "olympic-mountains"
+        "href": "olympic-mountains",
+        "active": true
     }, {
         "label": "The Sierra Nevadas",
         "href": "sierra-nevadas"

--- a/src/doc/data/side-nav-small.json
+++ b/src/doc/data/side-nav-small.json
@@ -1,108 +1,13 @@
 {
     "sections": [{
-        "label": "Deftones",
-        "pages": [{
-            "label": "Adrenaline",
-            "href": "adrenaline"
-        }, {
-            "label": "Around the Fur",
-            "href": "around-the-fur"
-        }, {
-            "label": "White Pony",
-            "href": "white-pony"
-        }, {
-            "label": "Deftones",
-            "href": "deftones"
-        }, {
-            "label": "Saturday Night Wrist",
-            "href": "saturday-night-wrist"
-        }, {
-            "label": "Diamond Eyes",
-            "href": "diamond-eyes"
-        }, {
-            "label": "Koi No Yokan",
-            "href": "koi-no-yokan"
-        }]
-    }, {
-        "label": "Radiohead",
-        "pages":[{
-            "label": "Pablo Honey",
-            "href": "pablo-honey"
-        }, {
-            "label": "The Bends",
-            "href": "the-bends"
-        }, {
-            "label": "OK Computer",
-            "href": "ok-computer"
-        }, {
-            "label": "Kid A",
-            "href": "kid-a"
-        }, {
-            "label": "Amnesiac",
-            "href": "amnesiac"
-        }, {
-            "label": "Hail to the Thief",
-            "href": "hail-to-the-thief"
-        }, {
-            "label": "In Rainbows",
-            "href": "in-rainbows"
-        }, {
-            "label": "The King of Limbs",
-            "href": "the-king-of-limbs"
-        }]
-    }, {
-        "label": "The Roots",
-        "pages":[{
-            "label": "Organix",
-            "href": "organix"
-        }, {
-            "label": "Do You Want More?!!!??!",
-            "href": "do-you-want-more"
-        }, {
-            "label": "Illadelph Halflife",
-            "href": "illadelp-halflife"
-        }, {
-            "label": "Things Fall Apart",
-            "href": "things-fall-apart"
-        }, {
-            "label": "Phrenology",
-            "href": "phrenology"
-        }, {
-            "label": "The Tipping Point",
-            "href": "the-tipping-point"
-        }, {
-            "label": "Game Theory",
-            "href": "game-theory"
-        }, {
-            "label": "Rising Down",
-            "href": "rising-down"
-        }, {
-            "label": "How I Got Over",
-            "href": "how-i-got-over"
-        }, {
-            "label": "Wake Up!",
-            "href": "wake-up"
-        }, {
-            "label": "Betty Wright: The Movie",
-            "href": "betty-wright-the-movie"
-        }, {
-            "label": "Undun",
-            "href": "undun"
-        }, {
-            "label": "Wise Up Ghost",
-            "href": "wise-up-ghost"
-        }, {
-            "label": "…And Then You Shoot Your Cousin",
-            "href": "and-then-you-shoot-your-cousin"
-        }]
-    }, {
         "label": "Father John Misty",
         "pages":[{
             "label": "Fear Fun",
             "href": "fear-fun"
         }, {
             "label": "I Love You Honeybear",
-            "href": "i-love-you-honeybear"
+            "href": "i-love-you-honeybear",
+            "active": true
         }]
     }, {
         "label": "The National",

--- a/src/doc/data/side-nav-small.json
+++ b/src/doc/data/side-nav-small.json
@@ -1,6 +1,6 @@
 {
     "sections": [{
-        "label": "Father John Misty",
+        "category": "Father John Misty",
         "id": "father-john-misty",
         "pages":[{
             "label": "Fear Fun",
@@ -11,7 +11,7 @@
             "active": true
         }]
     }, {
-        "label": "The National",
+        "category": "The National",
         "id": "the-national",
         "pages":[{
             "label": "The National",
@@ -33,7 +33,7 @@
             "href": "trouble-will-find-me"
         }]
     }, {
-        "label": "The Strokes",
+        "category": "The Strokes",
         "id": "the-strokes",
         "pages":[{
             "label": "Is this it?",
@@ -52,14 +52,14 @@
             "href": "comedown-machine"
         }]
     }, {
-        "label": "Glass Animals",
+        "category": "Glass Animals",
         "id": "glass-animals",
         "pages":[{
             "label": "Zaba",
             "href": "zaba"
         }]
     }, {
-        "label": "Imagine Dragons",
+        "category": "Imagine Dragons",
         "id": "imagine-dragons",
         "pages":[{
             "label": "Night Vision",

--- a/src/doc/data/side-nav-small.json
+++ b/src/doc/data/side-nav-small.json
@@ -1,0 +1,162 @@
+{
+    "sections": [{
+        "label": "Deftones",
+        "pages": [{
+            "label": "Adrenaline",
+            "href": "adrenaline"
+        }, {
+            "label": "Around the Fur",
+            "href": "around-the-fur"
+        }, {
+            "label": "White Pony",
+            "href": "white-pony"
+        }, {
+            "label": "Deftones",
+            "href": "deftones"
+        }, {
+            "label": "Saturday Night Wrist",
+            "href": "saturday-night-wrist"
+        }, {
+            "label": "Diamond Eyes",
+            "href": "diamond-eyes"
+        }, {
+            "label": "Koi No Yokan",
+            "href": "koi-no-yokan"
+        }]
+    }, {
+        "label": "Radiohead",
+        "pages":[{
+            "label": "Pablo Honey",
+            "href": "pablo-honey"
+        }, {
+            "label": "The Bends",
+            "href": "the-bends"
+        }, {
+            "label": "OK Computer",
+            "href": "ok-computer"
+        }, {
+            "label": "Kid A",
+            "href": "kid-a"
+        }, {
+            "label": "Amnesiac",
+            "href": "amnesiac"
+        }, {
+            "label": "Hail to the Thief",
+            "href": "hail-to-the-thief"
+        }, {
+            "label": "In Rainbows",
+            "href": "in-rainbows"
+        }, {
+            "label": "The King of Limbs",
+            "href": "the-king-of-limbs"
+        }]
+    }, {
+        "label": "The Roots",
+        "pages":[{
+            "label": "Organix",
+            "href": "organix"
+        }, {
+            "label": "Do You Want More?!!!??!",
+            "href": "do-you-want-more"
+        }, {
+            "label": "Illadelph Halflife",
+            "href": "illadelp-halflife"
+        }, {
+            "label": "Things Fall Apart",
+            "href": "things-fall-apart"
+        }, {
+            "label": "Phrenology",
+            "href": "phrenology"
+        }, {
+            "label": "The Tipping Point",
+            "href": "the-tipping-point"
+        }, {
+            "label": "Game Theory",
+            "href": "game-theory"
+        }, {
+            "label": "Rising Down",
+            "href": "rising-down"
+        }, {
+            "label": "How I Got Over",
+            "href": "how-i-got-over"
+        }, {
+            "label": "Wake Up!",
+            "href": "wake-up"
+        }, {
+            "label": "Betty Wright: The Movie",
+            "href": "betty-wright-the-movie"
+        }, {
+            "label": "Undun",
+            "href": "undun"
+        }, {
+            "label": "Wise Up Ghost",
+            "href": "wise-up-ghost"
+        }, {
+            "label": "…And Then You Shoot Your Cousin",
+            "href": "and-then-you-shoot-your-cousin"
+        }]
+    }, {
+        "label": "Father John Misty",
+        "pages":[{
+            "label": "Fear Fun",
+            "href": "fear-fun"
+        }, {
+            "label": "I Love You Honeybear",
+            "href": "i-love-you-honeybear"
+        }]
+    }, {
+        "label": "The National",
+        "pages":[{
+            "label": "The National",
+            "href": "the-national"
+        }, {
+            "label": "Songs for Dirty Lovers",
+            "href": "songs-for-dirty-lovers"
+        }, {
+            "label": "Alligator",
+            "href": "alligator"
+        }, {
+            "label": "Boxer",
+            "href": "boxer"
+        }, {
+            "label": "High Violet",
+            "href": "high-violet"
+        }, {
+            "label": "Trouble Will Find Me",
+            "href": "trouble-will-find-me"
+        }]
+    }, {
+        "label": "The Strokes",
+        "pages":[{
+            "label": "Is this it?",
+            "href": "is-this-it"
+        }, {
+            "label": "Room on Fire",
+            "href": "room-on-fire"
+        }, {
+            "label": "First Impressions of Earth",
+            "href": "first-impressions-of-earth"
+        }, {
+            "label": "Angels",
+            "href": "angels"
+        }, {
+            "label": "Comedown Machine",
+            "href": "comedown-machine"
+        }]
+    }, {
+        "label": "Glass Animals",
+        "pages":[{
+            "label": "Zaba",
+            "href": "zaba"
+        }]
+    }, {
+        "label": "Imagine Dragons",
+        "pages":[{
+            "label": "Night Vision",
+            "href": "night-vision"
+        }, {
+            "label": "Smoke + Mirrors",
+            "href": "smoke-mirrors"
+        }]
+    }]
+}

--- a/src/doc/data/side-nav-small.json
+++ b/src/doc/data/side-nav-small.json
@@ -1,6 +1,7 @@
 {
     "sections": [{
         "label": "Father John Misty",
+        "id": "father-john-misty",
         "pages":[{
             "label": "Fear Fun",
             "href": "fear-fun"
@@ -11,6 +12,7 @@
         }]
     }, {
         "label": "The National",
+        "id": "the-national",
         "pages":[{
             "label": "The National",
             "href": "the-national"
@@ -32,6 +34,7 @@
         }]
     }, {
         "label": "The Strokes",
+        "id": "the-strokes",
         "pages":[{
             "label": "Is this it?",
             "href": "is-this-it"
@@ -50,12 +53,14 @@
         }]
     }, {
         "label": "Glass Animals",
+        "id": "glass-animals",
         "pages":[{
             "label": "Zaba",
             "href": "zaba"
         }]
     }, {
         "label": "Imagine Dragons",
+        "id": "imagine-dragons",
         "pages":[{
             "label": "Night Vision",
             "href": "night-vision"

--- a/src/doc/partials/form/form-guidance.md.hbs
+++ b/src/doc/partials/form/form-guidance.md.hbs
@@ -1,6 +1,6 @@
 * Wrap labels and controls in `<div class="form-group">` for optimum spacing.
-* The following theme classes can be applied to the `<form>` or `<div class="form-group">` tags: `.theme-default`, `.theme-alt` or `.theme-dark`. Note: if `<button>` is inside `<form>` or `.form-group`, it does not automatically inherit the theme class. 
+* The following theme classes can be applied to the `<form>` or `<div class="form-group">` tags: `.theme-default`, `.theme-alt` or `.theme-dark`. Note: if `<button>` is inside `<form>` or `.form-group`, it does not automatically inherit the theme class.
 See documentation on [Buttons](./controls.html#buttons) for applying theme classes.
-* The `disabled` attribute can be applied to the `<input>` tags for all the form controls above. 
-* To get an indeterminate checkbox, apply the `.checkbox-indeterminate` class to the `<input type="checkbox">` tag along with the required javascript.
+* The `disabled` attribute can be applied to the `<input>` tags for all the form controls above.
+* To get an indeterminate checkbox, apply the `.checkbox-indeterminate` class to the `<input type="checkbox">` tag along with the required JavaScript.
 * The `checked` attribute is placed within the input tag of either checkbox or radio to indicate the it is pre-selected.

--- a/src/doc/partials/navbar.hbs
+++ b/src/doc/partials/navbar.hbs
@@ -68,6 +68,7 @@
                         <li><a href="controls.html#dialogs">Dialogs</a></li>
                         <li><a href="controls.html#tabs">Tabs</a></li>
                         <li><a href="controls.html#navs">Navbar</a></li>
+                        <li><a href="controls.html#side-nav">Side navigation</a></li>
                     </ul>
                 </li>
 

--- a/src/doc/partials/side-nav-guidance.md.hbs
+++ b/src/doc/partials/side-nav-guidance.md.hbs
@@ -1,0 +1,4 @@
+* Here is some guidance
+* Here is more guidance
+* Do This
+* Do not, whatever you do, DO NOT do this

--- a/src/doc/partials/side-nav-guidance.md.hbs
+++ b/src/doc/partials/side-nav-guidance.md.hbs
@@ -1,1 +1,0 @@
-* If you have a solid dark color or black background, add `theme-alt` at the same level as `side-navigation` to get white navigation links.

--- a/src/doc/partials/side-nav-guidance.md.hbs
+++ b/src/doc/partials/side-nav-guidance.md.hbs
@@ -1,4 +1,1 @@
-* Here is some guidance
-* Here is more guidance
-* Do This
-* Do not, whatever you do, DO NOT do this
+* If you have a solid color or black background, add `theme-alt` at the same level as `side-navigation` to get white navigation links.

--- a/src/doc/partials/side-nav-guidance.md.hbs
+++ b/src/doc/partials/side-nav-guidance.md.hbs
@@ -1,1 +1,1 @@
-* If you have a solid color or black background, add `theme-alt` at the same level as `side-navigation` to get white navigation links.
+* If you have a solid dark color or black background, add `theme-alt` at the same level as `side-navigation` to get white navigation links.

--- a/src/doc/partials/side-nav-large-about.md.hbs
+++ b/src/doc/partials/side-nav-large-about.md.hbs
@@ -1,1 +1,1 @@
-Large side nav is a one-level deep side navigation with an optional lable. Use in cases where site structure calls for flat, single-level architecture.
+Large side nav is a one-level deep side navigation with an optional label. Use in cases where site structure calls for flat, single-level architecture.

--- a/src/doc/partials/side-nav-large-about.md.hbs
+++ b/src/doc/partials/side-nav-large-about.md.hbs
@@ -1,1 +1,1 @@
-Large side nave is a one-level deep side navigation with an optional lable. Use in cases where site structure calls for flat, single-level architecture.
+Large side nav is a one-level deep side navigation with an optional lable. Use in cases where site structure calls for flat, single-level architecture.

--- a/src/doc/partials/side-nav-large-about.md.hbs
+++ b/src/doc/partials/side-nav-large-about.md.hbs
@@ -1,0 +1,1 @@
+Large side nave is a one-level deep side navigation with an optional lable. Use in cases where site structure calls for flat, single-level architecture.

--- a/src/doc/partials/side-nav-large-guidance.md.hbs
+++ b/src/doc/partials/side-nav-large-guidance.md.hbs
@@ -1,0 +1,5 @@
+* Use `.active` on nav link to denote current page/state in navigation
+* If you have a solid dark color or black background, add `.theme-alt` at the same level as `.side-navigation` to get white navigation links.
+* `.side-navigation` begins as `display: none;` at `$vp1` and becomes visible at `$vp3`
+* `a.navigation-btn` is visible on `$vp1` and `$vp2` to enable toggling visibility of `.side-navigation`
+* Use your own javaScript to show/hide navigation on `$vp1` and `$vp2`, though you can use ours below as a reference

--- a/src/doc/partials/side-nav-large-guidance.md.hbs
+++ b/src/doc/partials/side-nav-large-guidance.md.hbs
@@ -2,4 +2,4 @@
 * If you have a solid dark color or black background, add `.theme-alt` at the same level as `.side-navigation` to get white navigation links.
 * `.side-navigation` begins as `display: none;` at `$vp1` and becomes visible at `$vp3`
 * `a.navigation-btn` is visible on `$vp1` and `$vp2` to enable toggling visibility of `.side-navigation`
-* Use your own javaScript to show/hide navigation on `$vp1` and `$vp2`, though you can use ours below as a reference
+* Use your own JavaScript to show/hide navigation on `$vp1` and `$vp2`, though you can use ours below as a reference

--- a/src/doc/partials/side-nav-large.hbs
+++ b/src/doc/partials/side-nav-large.hbs
@@ -1,12 +1,14 @@
 {{#with side-nav-large}}
+<a class="btn btn-lightweight no-outline navigation-btn">{{category}}</a>
 <nav role="navigation" id="sidenav" class="nav side-navigation side-navigation-large theme-default">
-    <div class="navigation-label">{{label}}</div>
+    <div class="navigation-label">{{category}}</div>
+    <button type="button" class="close" data-dismiss="side-navigation" aria-label="close">
+        <i class="glyph glyph-cancel"></i>
+    </button>
     <ul>
         {{#each pages}}
-        <li>
-            {{!-- using dumb links, but you can easily pass in data via JSON or some other method --}}
-            <a href="#"{{#if active}} class="active"{{/if}}>{{label}}</a>
-        </li>
+        {{!-- using dumb links, but you can easily pass in data via JSON or some other method --}}
+        <li><a href="#"{{#if active}} class="active"{{/if}}>{{label}}</a></li>
         {{/each}}
     </ul>
 </nav>

--- a/src/doc/partials/side-nav-large.hbs
+++ b/src/doc/partials/side-nav-large.hbs
@@ -1,5 +1,5 @@
 {{#with side-nav-large}}
-<nav role="navigation" id="sidenav" class="nav side-navigation side-navigation-large">
+<nav role="navigation" id="sidenav" class="nav side-navigation side-navigation-large theme-default">
     <div class="navigation-label">{{label}}</div>
     <ul>
         {{#each pages}}

--- a/src/doc/partials/side-nav-large.hbs
+++ b/src/doc/partials/side-nav-large.hbs
@@ -4,7 +4,8 @@
     <ul>
         {{#each pages}}
         <li>
-            <a href="{{href}}.html" {{#compare ../../../basename href}} class="active" {{/compare}}>{{label}}</a>
+            {{!-- using dumb links, but you can easily pass in data via JSON or some other method --}}
+            <a href="#"{{#if active}} class="active"{{/if}}>{{label}}</a>
         </li>
         {{/each}}
     </ul>

--- a/src/doc/partials/side-nav-large.hbs
+++ b/src/doc/partials/side-nav-large.hbs
@@ -1,0 +1,12 @@
+{{#with side-nav-large}}
+<nav role="navigation" id="sidenav" class="nav side-navigation side-navigation-large">
+    <div class="navigation-label">{{label}}</div>
+    <ul>
+        {{#each pages}}
+        <li>
+            <a href="{{href}}.html" {{#compare ../../../basename href}} class="active" {{/compare}}>{{label}}</a>
+        </li>
+        {{/each}}
+    </ul>
+</nav>
+{{/with}}

--- a/src/doc/partials/side-nav-small-about.md.hbs
+++ b/src/doc/partials/side-nav-small-about.md.hbs
@@ -1,0 +1,1 @@
+Small side nave is a two-level deep side navigation. Use in cases where site structure calls for nested, two-level architecture.

--- a/src/doc/partials/side-nav-small-about.md.hbs
+++ b/src/doc/partials/side-nav-small-about.md.hbs
@@ -1,1 +1,1 @@
-Small side nave is a two-level deep side navigation. Use in cases where site structure calls for nested, two-level architecture.
+Small side nav is a two-level deep side navigation. Use in cases where site structure calls for nested, two-level architecture.

--- a/src/doc/partials/side-nav-small-guidance.md.hbs
+++ b/src/doc/partials/side-nav-small-guidance.md.hbs
@@ -3,4 +3,4 @@
 * Add `.panel` to `li.side-nav-c2` for full accordion operation
 * `.side-navigation` begins as `display: none;` at `$vp1` and becomes visible at `$vp3`
 * `a.navigation-btn` is visible on `$vp1` and `$vp2` to enable toggling visibility of `.side-navigation`
-* Use your own javaScript to show/hide navigation on `$vp1` and `$vp2`, though you can use the example from `.side-navigation-large` above as a reference
+* Use your own JavaScript to show/hide navigation on `$vp1` and `$vp2`, though you can use the example from `.side-navigation-large` above as a reference

--- a/src/doc/partials/side-nav-small-guidance.md.hbs
+++ b/src/doc/partials/side-nav-small-guidance.md.hbs
@@ -1,0 +1,6 @@
+* Use `.active` on `li.side-nav-c2` and it's child `a` nav link to denote current selected category and link
+* If you have a solid dark color or black background, add `.theme-alt` at the same level as `.side-navigation` to get white navigation links
+* Add `.panel` to `li.side-nav-c2` for full accordion operation
+* `.side-navigation` begins as `display: none;` at `$vp1` and becomes visible at `$vp3`
+* `a.navigation-btn` is visible on `$vp1` and `$vp2` to enable toggling visibility of `.side-navigation`
+* Use your own javaScript to show/hide navigation on `$vp1` and `$vp2`, though you can use the example from `.side-navigation-large` above as a reference

--- a/src/doc/partials/side-nav-small.hbs
+++ b/src/doc/partials/side-nav-small.hbs
@@ -6,7 +6,7 @@
     2. pages is the list of c3 pages in the each section, (not the assemble.io build-time variable pages). Checking to see if basename (i.e., current page we're assembling) is in the array of pages under the current c2 section, then we want to draw their side-nav as expanded.
     3. 'active' is merely a boolean value in the page object in side-nav-small.json
     --}}
-    <li class="{{#inArrayJson pages 'active'}}active {{/inArrayJson}}side-nav-c2">
+    <li class="panel {{#inArrayJson pages 'active'}}active {{/inArrayJson}}side-nav-c2">
         <a data-toggle="collapse" data-parent="#sidenav-small" href="#{{id}}" aria-expanded="{{#inArrayJson pages 'active'}}true{{else}}false{{/inArrayJson}}" aria-controls="#{{id}}">{{label}}</a>
         <ul class="nav collapse{{#inArrayJson pages 'active'}} in{{/inArrayJson}}" id="{{id}}">
             {{#each pages}}

--- a/src/doc/partials/side-nav-small.hbs
+++ b/src/doc/partials/side-nav-small.hbs
@@ -1,0 +1,21 @@
+{{#with side-nav-small}}
+<ul role="navigation" id="sidenav" class="nav side-navigation side-navigation-small">
+    {{#each sections}}
+    {{!-- a few notes about how the following lines function:
+    1. inArrayJson checks to see if a string exists in the stringified version of an array of JSON
+    2. pages is the list of c3 pages in the each section, (not the assemble.io build-time variable pages). Checking to see if basename (i.e., current page we're assembling) is in the array of pages under the current c2 section, then we want to draw their side-nav as expanded.
+    3. 'In Rainbows' is merely a page name under Radiohead, but you can imagine you might a basename or url or something for comparison
+    --}}
+    <li class="{{#inArrayJson pages 'In Rainbows'}}active expanded {{else}}collapsed {{/inArrayJson}}side-nav-c2">
+        <a>{{label}}</a>
+        <ul class="nav">
+            {{#each pages}}
+            <li>
+                <a href="{{href}}.html" {{#compare pages 'In Rainbows'}} class="active" {{/compare}}>{{label}}</a>
+            </li>
+            {{/each}}
+        </ul>
+    </li>
+    {{/each}}
+</ul>
+{{/with}}

--- a/src/doc/partials/side-nav-small.hbs
+++ b/src/doc/partials/side-nav-small.hbs
@@ -1,17 +1,18 @@
 {{#with side-nav-small}}
-<ul role="navigation" id="sidenav" class="nav side-navigation side-navigation-small">
+<ul role="navigation" id="sidenav" class="nav side-navigation side-navigation-small theme-alt">
     {{#each sections}}
     {{!-- a few notes about how the following lines function:
     1. inArrayJson checks to see if a string exists in the stringified version of an array of JSON
     2. pages is the list of c3 pages in the each section, (not the assemble.io build-time variable pages). Checking to see if basename (i.e., current page we're assembling) is in the array of pages under the current c2 section, then we want to draw their side-nav as expanded.
     3. 'In Rainbows' is merely a page name under Radiohead, but you can imagine you might a basename or url or something for comparison
     --}}
-    <li class="{{#inArrayJson pages 'In Rainbows'}}active expanded {{else}}collapsed {{/inArrayJson}}side-nav-c2">
-        <a>{{label}}</a>
+    <li class="{{#inArrayJson pages 'I Love You Honeybear'}}active expanded {{else}}collapsed {{/inArrayJson}}side-nav-c2">
+        <a href="#">{{label}}</a>
         <ul class="nav">
             {{#each pages}}
             <li>
-                <a href="{{href}}.html" {{#compare pages 'In Rainbows'}} class="active" {{/compare}}>{{label}}</a>
+                {{!-- using dumb links, but you can easily pass in data via JSON or some other method --}}
+                <a href="#"{{#if active}} class="active"{{/if}}>{{label}}</a>
             </li>
             {{/each}}
         </ul>

--- a/src/doc/partials/side-nav-small.hbs
+++ b/src/doc/partials/side-nav-small.hbs
@@ -1,18 +1,18 @@
 {{#with side-nav-small}}
-<ul role="navigation" id="sidenav" class="nav side-navigation side-navigation-small theme-alt">
+<ul role="navigation" id="sidenav-small" class="nav side-navigation side-navigation-small theme-default">
     {{#each sections}}
     {{!-- a few notes about how the following lines function:
     1. inArrayJson checks to see if a string exists in the stringified version of an array of JSON
     2. pages is the list of c3 pages in the each section, (not the assemble.io build-time variable pages). Checking to see if basename (i.e., current page we're assembling) is in the array of pages under the current c2 section, then we want to draw their side-nav as expanded.
-    3. 'In Rainbows' is merely a page name under Radiohead, but you can imagine you might a basename or url or something for comparison
+    3. 'active' is merely a boolean value in the page object in side-nav-small.json
     --}}
-    <li class="{{#inArrayJson pages 'I Love You Honeybear'}}active expanded {{else}}collapsed {{/inArrayJson}}side-nav-c2">
-        <a href="#">{{label}}</a>
-        <ul class="nav">
+    <li class="{{#inArrayJson pages 'active'}}active {{/inArrayJson}}side-nav-c2">
+        <a data-toggle="collapse" data-parent="#sidenav-small" href="#{{id}}" aria-expanded="{{#inArrayJson pages 'active'}}true{{else}}false{{/inArrayJson}}" aria-controls="#{{id}}">{{label}}</a>
+        <ul class="nav collapse{{#inArrayJson pages 'active'}} in{{/inArrayJson}}" id="{{id}}">
             {{#each pages}}
             <li>
                 {{!-- using dumb links, but you can easily pass in data via JSON or some other method --}}
-                <a href="#"{{#if active}} class="active"{{/if}}>{{label}}</a>
+                <a href="#sidenav-small"{{#if active}} class="active"{{/if}}>{{label}}</a>
             </li>
             {{/each}}
         </ul>

--- a/src/doc/partials/side-nav-small.hbs
+++ b/src/doc/partials/side-nav-small.hbs
@@ -1,19 +1,26 @@
 {{#with side-nav-small}}
+{{#each sections}}
+{{#inArrayJson pages 'active'}}
+<a class="btn btn-lightweight no-outline navigation-btn">{{category}}</a>
+{{/inArrayJson}}
+{{/each}}
 <ul role="navigation" id="sidenav-small" class="nav side-navigation side-navigation-small theme-default">
+    <button type="button" class="close" data-dismiss="side-navigation" aria-label="close">
+        <i class="glyph glyph-cancel"></i>
+    </button>
+
     {{#each sections}}
     {{!-- a few notes about how the following lines function:
     1. inArrayJson checks to see if a string exists in the stringified version of an array of JSON
     2. pages is the list of c3 pages in the each section, (not the assemble.io build-time variable pages). Checking to see if basename (i.e., current page we're assembling) is in the array of pages under the current c2 section, then we want to draw their side-nav as expanded.
     3. 'active' is merely a boolean value in the page object in side-nav-small.json
     --}}
-    <li class="panel {{#inArrayJson pages 'active'}}active {{/inArrayJson}}side-nav-c2">
-        <a data-toggle="collapse" data-parent="#sidenav-small" href="#{{id}}" aria-expanded="{{#inArrayJson pages 'active'}}true{{else}}false{{/inArrayJson}}" aria-controls="#{{id}}">{{label}}</a>
+    <li class="{{#inArrayJson pages 'active'}}active {{/inArrayJson}}side-nav-c2">
+        <a data-toggle="collapse" data-parent="#sidenav-small" href="#{{id}}" aria-expanded="{{#inArrayJson pages 'active'}}true{{else}}false{{/inArrayJson}}" aria-controls="#{{id}}">{{category}}</a>
         <ul class="nav collapse{{#inArrayJson pages 'active'}} in{{/inArrayJson}}" id="{{id}}">
             {{#each pages}}
-            <li>
-                {{!-- using dumb links, but you can easily pass in data via JSON or some other method --}}
-                <a href="#sidenav-small"{{#if active}} class="active"{{/if}}>{{label}}</a>
-            </li>
+            {{!-- using dumb links, but you can easily pass in data via JSON or some other method --}}
+            <li><a href="#sidenav-small"{{#if active}} class="active"{{/if}}>{{label}}</a></li>
             {{/each}}
         </ul>
     </li>

--- a/src/doc/partials/side-nav.js.hbs
+++ b/src/doc/partials/side-nav.js.hbs
@@ -1,15 +1,13 @@
 if ($('.side-navigation').length) {
-    var sideAffix = $('.side-navigation-affix');
-    var sideSection = $('.navigation-section');
     var closeBtn = $('.close');
-    var sideNav;
+    var sideAffix = $('.side-navigation-affix');
     var sideBtn = $('a.navigation-btn');
+    var sideNav = $('.side-navigation-large');
+    var sideSection = $('.navigation-section');
     var sideTopSpacing = 48;
 
     if ($('.side-navigation-small').length) {
         sideNav = $('.side-navigation-small');
-    } else {
-        sideNav = $('.side-navigation-large');
     }
 
     var topOffset = sideSection.offset().top - sideTopSpacing;

--- a/src/doc/partials/side-nav.js.hbs
+++ b/src/doc/partials/side-nav.js.hbs
@@ -1,0 +1,39 @@
+if ($('.side-navigation').length) {
+    var sideAffix = $('.side-navigation-affix');
+    var sideSection = $('.navigation-section');
+    var closeBtn = $('.close');
+    var sideNav;
+    var sideBtn = $('a.navigation-btn');
+    var sideTopSpacing = 48;
+
+    if ($('.side-navigation-small').length) {
+        sideNav = $('.side-navigation-small');
+    } else {
+        sideNav = $('.side-navigation-large');
+    }
+
+    var topOffset = sideSection.offset().top - sideTopSpacing;
+    var bottomOffset = $('body').height() - sideSection.offset().top - sideSection.height();
+
+    sideAffix.affix({
+        offset: {
+            top: topOffset,
+            bottom: bottomOffset
+        }
+    });
+
+    sideAffix.width(sideNav.parent().width());
+
+    sideBtn.on('click', function(){
+        sideNav.css("display", "block");
+        sideSection.css("display", "none");
+        sideBtn.css("display", "none");
+        $('body').css("overflow", "hidden");
+    });
+    closeBtn.on('click', function(){
+        sideNav.css("display", "");
+        sideSection.css("display", "");
+        sideBtn.css("display", "inline-block");
+        $('body').css("overflow", "");
+    });
+}

--- a/src/doc/partials/side-navigation.hbs
+++ b/src/doc/partials/side-navigation.hbs
@@ -1,0 +1,59 @@
+<div class="row">
+    <div class="col-xs-24">
+        <section class="section" id="side-nav">
+            <header class="section-header ">
+                <h1 class="section-title ">
+                    <a name="navs">Side navigation</a>
+                </h1>
+            </header>
+
+            <section class="section">
+                <h3>Large side navigation</h3>
+                <p>
+                    {{> side-nav-large-about.md }}
+                </p>
+                <div class="row m-t-md">
+                    <div class="col-md-6">
+                        {{> side-nav-large }}
+                    </div>
+                    <div class="col-xs-24 col-md-18">
+                        {{#markdown}}
+```xml
+{{> side-nav-large }}
+```
+                        {{/markdown}}
+                        <div class="guidance guidance-usage m-t-xs">
+                            {{#markdown}}
+{{> side-nav-guidance.md}}
+                            {{/markdown}}
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <section class="section">
+                <h3>Small side navigation</h3>
+                <p>
+                    {{> side-nav-small-about.md }}
+                </p>
+                <div class="row m-t-md">
+                    <div class="col-md-6">
+                        {{> side-nav-small }}
+                    </div>
+                    <div class="col-xs-24 col-md-18">
+                        {{#markdown}}
+```xml
+{{> side-nav-small }}
+```
+                        {{/markdown}}
+                        <div class="guidance guidance-usage m-t-xs">
+                            {{#markdown}}
+{{> side-nav-guidance.md}}
+                            {{/markdown}}
+                        </div>
+                    </div>
+                </div>
+            </section>
+        </section>
+    </div>
+</div>

--- a/src/doc/partials/side-navigation.hbs
+++ b/src/doc/partials/side-navigation.hbs
@@ -28,7 +28,7 @@
                             {{/markdown}}
                         </div>
                         {{#markdown}}
-```js
+```javascript
 {{> side-nav.js }}
 ```
                         {{/markdown}}

--- a/src/doc/partials/side-navigation.hbs
+++ b/src/doc/partials/side-navigation.hbs
@@ -16,7 +16,7 @@
                     <div class="col-md-6">
                         {{> side-nav-large }}
                     </div>
-                    <div class="col-xs-24 col-md-18">
+                    <div class="col-xs-24 col-md-18 navigation-section">
                         {{#markdown}}
 ```xml
 {{> side-nav-large }}
@@ -24,9 +24,14 @@
                         {{/markdown}}
                         <div class="guidance guidance-usage m-t-xs">
                             {{#markdown}}
-{{> side-nav-guidance.md}}
+{{> side-nav-large-guidance.md}}
                             {{/markdown}}
                         </div>
+                        {{#markdown}}
+```js
+{{> side-nav.js }}
+```
+                        {{/markdown}}
                     </div>
                 </div>
             </section>
@@ -48,7 +53,7 @@
                         {{/markdown}}
                         <div class="guidance guidance-usage m-t-xs">
                             {{#markdown}}
-{{> side-nav-guidance.md}}
+{{> side-nav-small-guidance.md}}
                             {{/markdown}}
                         </div>
                     </div>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -16,6 +16,50 @@
         }
     });
 
+    //
+    // Side Nav Large
+    //
+
+    if ($('.side-navigation').length) {
+        var sideAffix = $('.side-navigation-affix');
+        var sideSection = $('.navigation-section');
+        var closeBtn = $('.close');
+        var sideNav;
+        var sideBtn = $('a.navigation-btn');
+        var sideTopSpacing = 48;
+
+        if ($('.side-navigation-small').length) {
+            sideNav = $('.side-navigation-small');
+        } else {
+            sideNav = $('.side-navigation-large');
+        }
+
+        var topOffset = sideSection.offset().top - sideTopSpacing;
+        var bottomOffset = $('body').height() - sideSection.offset().top - sideSection.height();
+
+        sideAffix.affix({
+            offset: {
+                top: topOffset,
+                bottom: bottomOffset
+            }
+        });
+
+        sideAffix.width(sideNav.parent().width());
+
+        sideBtn.on('click', function(){
+            sideNav.css("display", "block");
+            sideSection.css("display", "none");
+            sideBtn.css("display", "none");
+            $('body').css("overflow", "hidden");
+        });
+        closeBtn.on('click', function(){
+            sideNav.css("display", "");
+            sideSection.css("display", "");
+            sideBtn.css("display", "inline-block");
+            $('body').css("overflow", "");
+        });
+    }
+
     // Alert stack
     (function () {
         var alertStack = $('.alert-stack');

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -21,17 +21,15 @@
     //
 
     if ($('.side-navigation').length) {
-        var sideAffix = $('.side-navigation-affix');
-        var sideSection = $('.navigation-section');
         var closeBtn = $('.close');
-        var sideNav;
+        var sideAffix = $('.side-navigation-affix');
         var sideBtn = $('a.navigation-btn');
+        var sideNav = $('.side-navigation-large');
+        var sideSection = $('.navigation-section');
         var sideTopSpacing = 48;
 
         if ($('.side-navigation-small').length) {
             sideNav = $('.side-navigation-small');
-        } else {
-            sideNav = $('.side-navigation-large');
         }
 
         var topOffset = sideSection.offset().top - sideTopSpacing;

--- a/src/scss/override/_navs.scss
+++ b/src/scss/override/_navs.scss
@@ -21,6 +21,15 @@ $pivot-hover-color-alt:                                                         
     }
 }
 
+// Need to get real specific to override Bootstrap here, hence descendant child selectors
+// Without this .side-navigation gets ugly backgrounds on hover & focus
+.nav > li {
+    > a:hover,
+    > a:focus {
+        background-color: transparent;
+    }
+}
+
 //
 // Nav pills
 //

--- a/src/scss/win/_side-navigation.scss
+++ b/src/scss/win/_side-navigation.scss
@@ -1,0 +1,195 @@
+.side-navigation {
+    &.side-navigation-large {
+        display: none;
+        cursor: text;
+        @media (min-width: $screen-md) {
+            display: block;
+            max-width: 225px;
+        }
+        .navigation-label {
+            position: relative;
+            margin-top: spacing(xs);
+            @include type(t4);
+            &:after {
+                position: absolute;
+                right: spacing(n);
+                bottom: spacing(n);
+                font-family: "winjs-symbols";
+                content: glyph(cancel);
+                font-size: 16px;
+                // This may change depending on the decided method for RTL
+                [dir="rtl"] & {
+                    right: auto;
+                    left: spacing(n);
+                }
+            }
+            @media (min-width: $screen-md) {
+                margin-top: spacing(md);
+                pointer-events: none;
+                &:after {
+                    display: none;
+                }
+            }
+        }
+        &.navigation-modal {
+            @extend .modal;
+            padding: spacing(n) spacing(xxs);
+            width: 100% !important;
+            overflow: auto;
+        }
+        &.side-navigation-affix {
+            @media (min-width: $screen-md) {
+                &.affix {
+                    top: spacing(n);
+                }
+                &.affix-bottom {
+                    position: absolute;
+                }
+            }
+        }
+        ul {
+            padding: spacing(n);
+            li {
+                padding: spacing(xxs) spacing(n);
+                word-wrap: break-word;
+                word-break: normal;
+                list-style-type: none;
+                .active {
+                    @extend .text-base;
+                }
+            }
+        }
+    }
+
+    &.side-navigation-small {
+        word-wrap: break-word;
+        word-break: normal;
+        display: block;
+        margin-top: spacing(lg);
+        &.affix {
+            margin-top: spacing(n);
+            top: spacing(xxs);
+            position: fixed;
+        }
+        &.affix-bottom {
+            position: absolute;
+        }
+        &.nav {
+            >li a {
+                padding-top: spacing(xxxs)/3;
+                padding-bottom: spacing(xxxs)/3;
+                cursor: pointer;
+            }
+            .side-nav-c2 {
+                position: relative;
+                a {
+                    padding-left: spacing(n);
+                }
+                &.with-icon {
+                    a {
+                        padding-left: spacing(xxs);
+                    }
+                    &:before {
+                        position: absolute;
+                        top: 7px;
+                        font-size: 10px;
+                        font-family: "winjs-symbols";
+                        content: glyph(add);
+                    }
+                    &.active {
+                        &.with-icon:before {
+                            content: glyph(remove);
+                        }
+                    }
+                }
+            }
+            .nav {
+                display: none;
+                margin: spacing(n);
+                padding-left: spacing(xxs);
+                li a {
+                    padding-top: spacing(xxxs)/4;
+                    padding-bottom: spacing(xxxs)/4;
+                }
+            }
+            &.nav li.active .nav {
+                display: block;
+            }
+        }
+    }
+
+    .navigation-btn {
+        position: relative;
+        margin: spacing(n);
+        padding-left: spacing(sm);
+        [dir="rtl"] & {
+            padding-right: spacing(sm);
+        }
+        &:before {
+            position: absolute;
+            left: spacing(n);
+            font-family: "winjs-symbols";
+            content: glyph(back);
+            // This may change depending on the decided method for RTL
+            [dir="rtl"] & {
+                left: auto;
+                right: spacing(n);
+                content: glyph(forward);
+            }
+        }
+        @media (min-width: $screen-md) {
+            display: none;
+        }
+    }
+
+    //
+    // Colors
+    //
+
+    // Default
+    &.navigation-modal {
+        background-color: $color-bg-light-vivid-high;
+    }
+    a {
+        color: $color-type-secondary;
+    }
+    .active {
+        color: $color-type-primary;
+    }
+
+    // Alt Theme
+    &.theme-alt {
+        &.navigation-modal {
+            background-color: $color-bg-dark-vivid-high;
+        }
+        .navigation-label {
+            color: $color-type-primary-alt;
+            &:after {
+                color: $color-vivid-low-alt;
+            }
+        }
+        a {
+            color: $color-type-secondary-alt;
+        }
+        .active {
+            color: $color-type-primary-alt;
+        }
+    }
+
+    .side-nav-c2 {
+        // Default
+        a {
+            color: $color-type-secondary;
+        }
+        &:hover {
+            color: $color-type-secondary;
+        }
+        .active {
+            background-color: $color-bg-light-vivid-low;
+        }
+        // Alt Theme
+        &.theme-alt {
+            color: $color-type-secondary-alt;
+        }
+    }
+}

--- a/src/scss/win/_side-navigation.scss
+++ b/src/scss/win/_side-navigation.scss
@@ -21,7 +21,7 @@ a.navigation-btn {
         }
     }
     @media (min-width: $screen-md) {
-        // Have to use !important because show/hide behavior via javascript is styled inline
+        // Have to use !important because show/hide behavior via JavaScript is styled inline
         display: none !important;
     }
 

--- a/src/scss/win/_side-navigation.scss
+++ b/src/scss/win/_side-navigation.scss
@@ -1,3 +1,46 @@
+// This is for viewports 1 & 2 and lives outside the .side-navigation structure to be visible when .side-navigation is not
+a.navigation-btn {
+    position: relative;
+    margin-top: spacing(xs);
+    padding-left: spacing(sm);
+    [dir="rtl"] & {
+        padding-right: spacing(sm);
+    }
+    &:hover {
+        text-decoration: none;
+    }
+    &:before {
+        position: absolute;
+        left: spacing(n);
+        @include glyph(back);
+        // This may change depending on the decided method for RTL
+        [dir="rtl"] & {
+            left: auto;
+            right: spacing(n);
+            content: glyph(forward);
+        }
+    }
+    @media (min-width: $screen-md) {
+        // Have to use !important because show/hide behavior via javascript is styled inline
+        display: none !important;
+    }
+
+    //
+    // Color
+    //
+    &,
+    &.theme-default,
+    &.btn-lightweight:hover {
+        color: $color-type-secondary;
+    }
+    &.theme-alt {
+        color: $color-type-secondary-alt;
+        &.btn-lightweight:hover {
+            color: $color-type-secondary-alt;
+        }
+    }
+}
+
 .side-navigation {
 
     &.side-navigation-large {
@@ -6,37 +49,6 @@
         @media (min-width: $screen-md) {
             display: block;
             max-width: 225px;
-        }
-        .navigation-label {
-            position: relative;
-            margin-top: spacing(xs);
-            @include type(t4);
-            font-weight: 400;
-            &:after {
-                position: absolute;
-                right: spacing(n);
-                bottom: spacing(n);
-                @include glyph(cancel);
-                font-size: 16px;
-                // This may change depending on the decided method for RTL
-                [dir="rtl"] & {
-                    right: auto;
-                    left: spacing(n);
-                }
-            }
-            @media (min-width: $screen-md) {
-                margin-top: spacing(md);
-                pointer-events: none;
-                &:after {
-                    display: none;
-                }
-            }
-        }
-        &.navigation-modal {
-            @extend .modal;
-            padding: spacing(n) spacing(xxs);
-            width: 100% !important;
-            overflow: auto;
         }
         &.side-navigation-affix {
             @media (min-width: $screen-md) {
@@ -60,13 +72,24 @@
                 }
             }
         }
+        .close {
+            position: absolute;
+            top: 23px;
+            right: 9px;
+            font-size: 18px;
+            padding: spacing(xxxs, 1);
+            @media (min-width: $screen-md) {
+                display: none;
+            }
+        }
     }
 
     &.side-navigation-small {
         word-wrap: break-word;
         word-break: normal;
-        display: block;
+        display:  none;
         margin-top: spacing(lg);
+        max-width: calc(100% - 32px); // make space for .close on $vp1 & $vp2
         &.affix {
             margin-top: spacing(n);
             top: spacing(xxs);
@@ -74,6 +97,10 @@
         }
         &.affix-bottom {
             position: absolute;
+        }
+        @media (min-width: $screen-md) {
+            display: block;
+            max-width: initial; // then let it be full-width on $vp3 and higher
         }
         &.nav {
             >li a {
@@ -130,28 +157,26 @@
                 box-shadow: none;
             }
         }
-    }
-
-    .navigation-btn {
-        position: relative;
-        margin: spacing(n);
-        padding-left: spacing(sm);
-        [dir="rtl"] & {
-            padding-right: spacing(sm);
-        }
-        &:before {
+        .close {
             position: absolute;
-            left: spacing(n);
-            @include glyph(back);
-            // This may change depending on the decided method for RTL
-            [dir="rtl"] & {
-                left: auto;
-                right: spacing(n);
-                content: glyph(forward);
+            top: -8px;
+            right: 10px;
+            font-size: 15px;
+            padding: spacing(xxxs);
+            @media (min-width: $screen-md) {
+                display: none;
             }
         }
+    }
+
+    .navigation-label {
+        // position: relative;
+        margin-top: spacing(xs);
+        @include type(t4);
+        font-weight: 400;
         @media (min-width: $screen-md) {
-            display: none;
+            margin-top: spacing(md);
+            pointer-events: none;
         }
     }
 
@@ -163,7 +188,7 @@
     &,
     &.theme-default {
         &.navigation-modal {
-            background-color: transparent;
+            background-color: $color-vivid-high-alt;
         }
         a {
             color: $color-type-secondary;

--- a/src/scss/win/_side-navigation.scss
+++ b/src/scss/win/_side-navigation.scss
@@ -119,9 +119,16 @@
                     @include type(t8);
                 }
             }
-            // &.nav li.active .nav {
-            //     display: block;
-            // }
+
+            // Override Panel settings
+            // Panel is required for Bootstrap's accordion
+            .panel {
+                margin: initial;
+                background: transparent;
+                border: 0;
+                border-color: transparent;
+                box-shadow: none;
+            }
         }
     }
 

--- a/src/scss/win/_side-navigation.scss
+++ b/src/scss/win/_side-navigation.scss
@@ -1,4 +1,5 @@
 .side-navigation {
+
     &.side-navigation-large {
         display: none;
         cursor: text;
@@ -10,6 +11,7 @@
             position: relative;
             margin-top: spacing(xs);
             @include type(t4);
+            font-weight: 400;
             &:after {
                 position: absolute;
                 right: spacing(n);
@@ -76,12 +78,13 @@
         }
         &.nav {
             >li a {
-                padding-top: spacing(xxxs)/3;
-                padding-bottom: spacing(xxxs)/3;
+                padding-top: spacing(n);
+                padding-bottom: spacing(n);
                 cursor: pointer;
             }
             .side-nav-c2 {
                 position: relative;
+                @include type(t7);
                 a {
                     padding-left: spacing(n);
                 }
@@ -103,13 +106,19 @@
                     }
                 }
             }
+
+            .side-nav-c2:not(:first-of-type) {
+                margin-top: spacing(xxs);
+            }
+
             .nav {
                 display: none;
                 margin: spacing(n);
-                padding-left: spacing(xxs);
+                padding-left: spacing(xs);
                 li a {
                     padding-top: spacing(xxxs)/4;
                     padding-bottom: spacing(xxxs)/4;
+                    @include type(t8);
                 }
             }
             &.nav li.active .nav {
@@ -146,15 +155,34 @@
     // Colors
     //
 
-    // Default
+    // Default Theme
     &.navigation-modal {
-        background-color: $color-bg-light-vivid-high;
+        background-color: transparent;
     }
     a {
         color: $color-type-secondary;
+        &:hover {
+            text-decoration: underline;
+        }
     }
     .active {
         color: $color-type-primary;
+        font-weight: 400;
+    }
+
+    .side-nav-c2 {
+        a {
+            color: $color-type-secondary;
+            &:hover {
+                text-decoration: underline;
+                background-color: transparent;
+            }
+        }
+        &.active > a,
+        .active {
+            color: $color-type-primary;
+            background-color: transparent;
+        }
     }
 
     // Alt Theme
@@ -174,22 +202,14 @@
         .active {
             color: $color-type-primary-alt;
         }
-    }
-
-    .side-nav-c2 {
-        // Default
-        a {
-            color: $color-type-secondary;
-        }
-        &:hover {
-            color: $color-type-secondary;
-        }
-        .active {
-            background-color: $color-bg-light-vivid-low;
-        }
-        // Alt Theme
-        &.theme-alt {
-            color: $color-type-secondary-alt;
+        .side-nav-c2 {
+            a {
+                color: $color-type-secondary-alt;
+            }
+            &.active > a,
+            .active {
+                color: $color-type-primary-alt;
+            }
         }
     }
 }

--- a/src/scss/win/_side-navigation.scss
+++ b/src/scss/win/_side-navigation.scss
@@ -16,8 +16,7 @@
                 position: absolute;
                 right: spacing(n);
                 bottom: spacing(n);
-                font-family: "winjs-symbols";
-                content: glyph(cancel);
+                @include glyph(cancel);
                 font-size: 16px;
                 // This may change depending on the decided method for RTL
                 [dir="rtl"] & {
@@ -96,8 +95,7 @@
                         position: absolute;
                         top: 7px;
                         font-size: 10px;
-                        font-family: "winjs-symbols";
-                        content: glyph(add);
+                        @include glyph(add);
                     }
                     &.active {
                         &.with-icon:before {
@@ -112,7 +110,7 @@
             }
 
             .nav {
-                display: none;
+                // display: none;
                 margin: spacing(n);
                 padding-left: spacing(xs);
                 li a {
@@ -121,9 +119,9 @@
                     @include type(t8);
                 }
             }
-            &.nav li.active .nav {
-                display: block;
-            }
+            // &.nav li.active .nav {
+            //     display: block;
+            // }
         }
     }
 
@@ -137,8 +135,7 @@
         &:before {
             position: absolute;
             left: spacing(n);
-            font-family: "winjs-symbols";
-            content: glyph(back);
+            @include glyph(back);
             // This may change depending on the decided method for RTL
             [dir="rtl"] & {
                 left: auto;
@@ -156,32 +153,35 @@
     //
 
     // Default Theme
-    &.navigation-modal {
-        background-color: transparent;
-    }
-    a {
-        color: $color-type-secondary;
-        &:hover {
-            text-decoration: underline;
+    &,
+    &.theme-default {
+        &.navigation-modal {
+            background-color: transparent;
         }
-    }
-    .active {
-        color: $color-type-primary;
-        font-weight: 400;
-    }
-
-    .side-nav-c2 {
         a {
             color: $color-type-secondary;
             &:hover {
                 text-decoration: underline;
-                background-color: transparent;
             }
         }
-        &.active > a,
         .active {
             color: $color-type-primary;
-            background-color: transparent;
+            font-weight: 400;
+        }
+
+        .side-nav-c2 {
+            a {
+                color: $color-type-secondary;
+                &:hover {
+                    text-decoration: underline;
+                    background-color: transparent;
+                }
+            }
+            &.active > a,
+            .active {
+                color: $color-type-primary;
+                background-color: transparent;
+            }
         }
     }
 

--- a/src/scss/winstrap.scss
+++ b/src/scss/winstrap.scss
@@ -59,6 +59,7 @@
 @import "win/alerts";
 @import "win/pager";
 @import "win/pagination";
+@import "win/side-navigation";
 
 // Layout
 @import "win/main";


### PR DESCRIPTION
This creates a new component in Winstrap for side navigation. It has two available sizes,  `.side-navigation-large` for menus with single-level depth, and `.side-navigation-small` for menus with two-level depth. `.side-navigation-small` has optional accordion behavior thanks to Bootstrap's accordion/panel combo. Each navigation option has `.theme-default` and `.theme-default`.