### PR TITLE
npm cannot find image files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -55,6 +55,12 @@ module.exports = function (grunt) {
             src: '**',
             dest: './dist/fonts/'
           },
+          {
+            expand: true,
+            cwd: './src/images/',
+            src: '*',
+            dest: './dist/images/'
+          },
           
           //  Copy vendor js to dist and www
           {


### PR DESCRIPTION
Working with an angular project. Ran npm install winstrap, and the css file could not find images unless they were copied into the dist directory.