### PR TITLE
Solve "cannot find module 'winstrap'" problem.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+module.exports = __dirname;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "type": "git",
     "url": "git+https://github.com/winjs/winstrap.git"
   },
-  "version": "0.5.12",
+  "version": "0.5.13",
   "author": "Microsoft",
   "contributors": [
     "Frederic Perrin",
@@ -40,7 +40,7 @@
   "bugs": {
     "url": "https://github.com/winjs/winstrap/issues"
   },
-  "main": "dist/*",
+  "main": "index.js",
   "keywords": [
     "microsoft",
     "windows",


### PR DESCRIPTION
I want to use `var winstrap = require('winstrap');` directly.

But it will get an Error: `Cannot find module 'winstrap'`.

So I create this pull request.

Then we can use it like: 
```js
const express = require('express');
const winstrap = require('winstrap');
const path = require('path');
const app = express();
app.use('/winstrap_dist', path.join(winstrap, 'dist');
```